### PR TITLE
Add guide for FP8 wqkv weight_scale_inv loading

### DIFF
--- a/docs/features/quantization/lmhead_vocab_embedding_tp_weight_loader.md
+++ b/docs/features/quantization/lmhead_vocab_embedding_tp_weight_loader.md
@@ -1,0 +1,96 @@
+---
+title: Loading LMHead and vocab embeddings with TP
+---
+
+This guide describes how the tensor-parallel (TP) versions of
+`VocabParallelEmbedding` and `ParallelLMHead` load their weights using the
+built‑in weight loader. The Qwen2 model is used as the example.
+
+## Qwen2 model construction
+
+Both the token embedding layer and the LM head are sharded across TP
+ranks. They are constructed using `VocabParallelEmbedding` and
+`ParallelLMHead`:
+
+```python
+self.embed_tokens = VocabParallelEmbedding(
+    config.vocab_size,
+    config.hidden_size,
+    quant_config=quant_config,
+    prefix=f"{prefix}.embed_tokens",
+)
+...
+self.lm_head = ParallelLMHead(
+    config.vocab_size,
+    config.hidden_size,
+    quant_config=quant_config,
+    prefix=maybe_prefix(prefix, "lm_head"),
+)
+```
+
+{cite:3cb583L303-L310}
+{cite:071594L454-L458}
+
+## Registering the weight loader
+
+`VocabParallelEmbedding` registers a custom `weight_loader` when creating
+its parameters. This loader slices the incoming tensor according to the
+TP shard and copies it into the parameter:
+
+```python
+self.quant_method.create_weights(
+    self,
+    self.embedding_dim,
+    [self.num_embeddings_per_partition],
+    self.embedding_dim,
+    self.num_embeddings_padded,
+    params_dtype=params_dtype,
+    weight_loader=self.weight_loader,
+)
+```
+
+{cite:37b2f0L266-L272}
+
+## Loading weights
+
+During `AutoWeightsLoader.load_weights`, each parameter's `weight_loader`
+is invoked instead of the default loader:
+
+```python
+weight_loader = getattr(param, "weight_loader", default_weight_loader)
+weight_loader(param, weight_data)
+```
+
+{cite:b911eeL166-L168}
+
+For embeddings, this method ultimately calls
+`VocabParallelEmbedding.weight_loader`:
+
+```python
+def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+    output_dim = getattr(param, "output_dim", None)
+    ...
+    start_idx = self.shard_indices.org_vocab_start_index
+    shard_size = self.shard_indices.org_vocab_end_index - start_idx
+    loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+    param[:loaded_weight.shape[0]].data.copy_(loaded_weight)
+    param[loaded_weight.shape[0]:].data.fill_(0)
+```
+
+{cite:fe0c0eL351-L404}
+
+This function computes the correct shard indices for the current TP rank
+and loads only that portion of the checkpoint tensor. The LM head reuses
+the same loader because it inherits from `VocabParallelEmbedding`.
+
+## Summary
+
+1. `VocabParallelEmbedding` and `ParallelLMHead` are used for TP
+   embeddings and LM logits.
+2. `create_weights` attaches `weight_loader` so each parameter knows how
+   to slice its checkpoint tensor.
+3. `AutoWeightsLoader` retrieves this loader and calls it when processing
+   the state dict.
+4. `VocabParallelEmbedding.weight_loader` copies only the relevant shard,
+   ensuring embeddings and LM head weights are correctly initialized on
+   each rank.

--- a/docs/features/quantization/wqkv_tp_weight_scale_inv.md
+++ b/docs/features/quantization/wqkv_tp_weight_scale_inv.md
@@ -1,0 +1,145 @@
+---
+title: Loading wqkv weight_scale_inv for FP8 TP
+---
+
+This guide explains how the `weight_scale_inv` parameter of the fused
+qkv projection (named `qkv_proj` in the Qwen2 model) is loaded when
+using FP8 quantization with tensor parallelism (TP).  The same loading
+flow applies to models that expose `wqkv` parameters.
+
+## Overview
+
+1. **Model initialization** – Qwen2 creates a `QKVParallelLinear`
+   layer for `qkv_proj` with the provided `quant_config`.
+2. **Parameter creation** – `Fp8LinearMethod.create_weights` registers
+   the `weight` tensor and, when block-wise quantization is enabled,
+   a `weight_scale_inv` parameter.
+3. **Weight loading** – during `AutoWeightsLoader.load_weights`, each
+   parameter receives a state‑dict tensor. For TP layers the loader
+   splits the tensor according to the shard id before copying it into
+   the parameter.
+4. **Post‑processing** – after all weights are loaded,
+   `process_weights_after_loading` is called. For FP8 this converts the
+   loaded scales and ensures the tensors are in the correct layout for
+   inference.
+
+The following sections walk through these steps with code references.
+
+## Qwen2 attention
+
+The attention block constructs the fused QKV projection:
+
+```python
+self.qkv_proj = QKVParallelLinear(
+    hidden_size,
+    self.head_dim,
+    self.total_num_heads,
+    self.total_num_kv_heads,
+    bias=True,
+    quant_config=quant_config,
+    prefix=f"{prefix}.qkv_proj",
+)
+```
+
+{cite:bcd2e8L136-L144}
+
+## Parameter registration
+
+During initialization of `QKVParallelLinear`, the FP8 quantization
+method creates the scale parameter:
+
+```python
+scale = BlockQuantScaleParameter(
+    data=torch.empty(
+        (output_size_per_partition + block_n - 1) // block_n,
+        (input_size_per_partition + block_k - 1) // block_k,
+        dtype=torch.float32,
+    ),
+    input_dim=1,
+    output_dim=0,
+    weight_loader=weight_loader,
+)
+scale[:] = torch.finfo(torch.float32).min
+set_weight_attrs(scale, {"scale_type": "weight_scale"})
+# The weight_scale_inv name is intentional for deepseekv3
+layer.register_parameter("weight_scale_inv", scale)
+```
+
+{cite:00e5c0L280-L299}
+
+## Loading shards
+
+`QKVParallelLinear.weight_loader_v2` handles loading each tensor
+shard according to the TP rank. For scale parameters it computes the
+correct offset using the block size:
+
+```python
+if isinstance(param, BlockQuantScaleParameter):
+    weight_block_size = self.quant_method.quant_config.weight_block_size
+    block_n, _ = weight_block_size[0], weight_block_size[1]
+    shard_offset = ((sum(self.output_sizes[:loaded_shard_id]) + block_n - 1)
+                    // block_n) // tp_size
+    shard_size = ((self.output_sizes[loaded_shard_id] + block_n - 1)
+                  // block_n // tp_size)
+else:
+    shard_offset = sum(self.output_sizes[:loaded_shard_id]) // tp_size
+    shard_size = self.output_sizes[loaded_shard_id] // tp_size
+param.load_merged_column_weight(
+    loaded_weight=loaded_weight,
+    shard_id=loaded_shard_id,
+    shard_offset=shard_offset,
+    shard_size=shard_size,
+)
+```
+
+{cite:c4604eL730-L782}
+
+`load_merged_column_weight` on `BlockQuantScaleParameter` copies the
+correct slice into the parameter tensor while respecting TP partitioning.
+
+## Post‑processing after loading
+
+Once all state‑dict tensors are loaded, weight post‑processing runs:
+
+```python
+for _, module in model.named_modules():
+    quant_method = getattr(module, "quant_method", None)
+    if isinstance(quant_method, QuantizeMethodBase):
+        with device_loading_context(module, target_device):
+            quant_method.process_weights_after_loading(module)
+```
+
+{cite:c6be5cL96-L113}
+
+For FP8 and block quantization this method converts the weight and scale
+buffers and reassigns them as standard `Parameter` objects:
+
+```python
+if self.block_quant:
+    weight, weight_scale_inv, _ = normalize_e4m3fn_to_e4m3fnuz(
+        weight=layer.weight,
+        weight_scale=layer.weight_scale_inv)
+    weight = self._maybe_pad_weight(weight)
+    layer.weight = Parameter(weight, requires_grad=False)
+    layer.weight_scale_inv = Parameter(weight_scale_inv,
+                                       requires_grad=False)
+```
+
+{cite:00e5c0L311-L331}
+
+At this point the `weight_scale_inv` tensor for each TP shard is ready
+for inference.
+
+## Summary
+
+1. `Qwen2Attention` builds `qkv_proj` with `QKVParallelLinear`.
+2. `Fp8LinearMethod.create_weights` registers `weight_scale_inv` when
+   block quantization is enabled.
+3. `AutoWeightsLoader` calls `weight_loader_v2` which partitions the
+   scale tensor by TP rank and copies it into the parameter.
+4. `process_weights_after_loading` finalizes the FP8 tensors,
+   converting the scales if necessary.
+
+Understanding this flow helps debug issues with FP8 checkpoint loading
+and ensures the `weight_scale_inv` parameters are correctly initialized
+for tensor parallel inference.


### PR DESCRIPTION
## Summary
- document how `weight_scale_inv` is loaded for FP8 tensor-parallel models

## Testing
- `pre-commit run --files docs/features/quantization/wqkv_tp_weight_scale_inv.md`

------
https://chatgpt.com/codex/tasks/task_e_68738ca97030832c9ec0ccac37b4745a